### PR TITLE
Ensure qt-sql bindings are installed.

### DIFF
--- a/debian-jessie/Dockerfile
+++ b/debian-jessie/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get -y update && \
             python3-pyqt5 \
             python3-pyqt5.qtquick \
             python3-pyqt5.qtwebkit \
+            python3-pyqt5.qtsql \
             python-tox \
             python3-sip \
             xvfb \

--- a/ubuntu-xenial/Dockerfile
+++ b/ubuntu-xenial/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get -y update && \
             python3-pyqt5 \
             python3-pyqt5.qtquick \
             python3-pyqt5.qtwebkit \
+            python3-pyqt5.qtsql \
             python-tox \
             python3-sip \
             xvfb \


### PR DESCRIPTION
These are include in the Archlinux pyqt package but must be explicitly
installed on Debian and Ubuntu. The SQL bindings are needed for the new
SQL-based completion implementation.

See The-Compiler/qutebrowser#1765.