### PR TITLE
Install libq5sql5-sqlite on debian/ubuntu.

### DIFF
--- a/debian-jessie/Dockerfile
+++ b/debian-jessie/Dockerfile
@@ -18,7 +18,9 @@ RUN apt-get -y update && \
             python3-setuptools \
             wget \
             locales \
-            libjs-pdf
+            libjs-pdf \
+            libqt5sql5-sqlite
+
 RUN echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen
 
 RUN useradd user && mkdir /home/user && chown -R user:users /home/user

--- a/ubuntu-xenial/Dockerfile
+++ b/ubuntu-xenial/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get -y update && \
             wget \
             language-pack-en \
             libjs-pdf \
-            dbus
+            dbus \
+            libqt5sql5-sqlite
 
 RUN dbus-uuidgen --ensure
 


### PR DESCRIPTION
This is needed to suport the new SQL completion backend.
I updated the travis_install script in the main qutebrowser repo but that
doesn't seem to be enough.