### PR TITLE
Install xorg-xdpyinfo on arch too.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
 
 script:
   - travis_retry docker build -t "qutebrowser/travis:$IMAGE" "$IMAGE"
-  - '[[ $TRAVIS_PULL_REQUEST == false ]] && docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"'
-  - '[[ $TRAVIS_PULL_REQUEST == false ]] && docker push "qutebrowser/travis:$IMAGE"'
+  - 'if [[ $TRAVIS_PULL_REQUEST == false ]]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi'
+  - 'if [[ $TRAVIS_PULL_REQUEST == false ]]; then docker push "qutebrowser/travis:$IMAGE"; fi'
 
 notifications:
   irc:

--- a/archlinux-webengine/Dockerfile
+++ b/archlinux-webengine/Dockerfile
@@ -13,7 +13,8 @@ RUN pacman -Suyy --noconfirm \
     xorg-server-xvfb \
     ttf-bitstream-vera \
     gcc \
-    libyaml
+    libyaml \
+    xorg-xdpyinfo
 
 USER user
 WORKDIR /home/user

--- a/archlinux/Dockerfile
+++ b/archlinux/Dockerfile
@@ -12,7 +12,8 @@ RUN pacman -Suyy --noconfirm \
     xorg-server-xvfb \
     ttf-bitstream-vera \
     gcc \
-    libyaml
+    libyaml \
+    xorg-xdpyinfo
 
 USER user
 WORKDIR /home/user


### PR DESCRIPTION
Since a new release was made to PyVirtualDisplay that included [a commit][commit] which tries to run `xdpyinfo` it is [now][] failing tests because of its absence. For two reasons:

* warning messages fail tests unless ignored with caplog
* DeprecationWarnings (from using `log.warn`) may also fail tests

This wouldn't normally be a problem because it is only run when it is set up which is done before the tests start running. Unfortunately the integration between and coverage.py appears to be re-importing parts of the test setup so now all the tests around coverage are breaking.

It looks like there might be ways to tweak how pytest and coverage.py work together but that code looks a little convoluted in this is probably the easiest fix.

I also opened a PR there for s/log.warn/log.warning/.

[commit]: https://github.com/ponty/PyVirtualDisplay/commit/3b11cf1e1381921c047ba18f4c5d929847f23b84
[now]: https://github.com/qutebrowser/qutebrowser/pull/4812