### PR TITLE
Run tox using dbus-run-session

### DIFF
--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -24,4 +24,4 @@ WORKDIR /home/user
 
 CMD git clone /outside qutebrowser.git && \
     cd qutebrowser.git && \
-    tox -e py38
+    dbus-run-session -- tox -e py38


### PR DESCRIPTION
This is necessary for testing the notification support in qutebrowser/qutebrowser#4780, which spins up a dbus server.